### PR TITLE
Configuration for enum fields cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"consistence/consistence-doctrine": "~1.0",
+		"consistence/consistence-doctrine": "~1.1",
 		"doctrine/doctrine-bundle": "~1.3",
 		"symfony/config": "~3.0",
 		"symfony/dependency-injection": "~3.0",

--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,21 @@ class Consistence\Doctrine\Example\User\Sex#5740 (1) {
 
 This means that the objects API is symmetrical (you get the same type as you set) and you can start benefiting from [Enums](https://github.com/consistence/consistence/blob/master/docs/Enum/enums.md) advantages such as being sure, that what you get is already a valid value and having the possibility to define methods on top of the represented values.
 
+Configuration
+-------------
+
+You can override services used internally, for example if you want to use a more effective cache in production (which is recommended), you can provide custom instance with an [alias](http://symfony.com/doc/current/components/dependency_injection/advanced.html#aliasing):
+
+```yaml
+services:
+    mycache:
+        class: Doctrine\Common\Cache\FilesystemCache
+        arguments:
+            - '%kernel.cache_dir%/mycache'
+
+    consistence.doctrine.enum.enum_fields_cache: '@mycache'
+```
+
 Installation
 ------------
 

--- a/src/DependencyInjection/config/services.yml
+++ b/src/DependencyInjection/config/services.yml
@@ -3,5 +3,11 @@ services:
         class: Consistence\Doctrine\Enum\EnumPostLoadEntityListener
         arguments:
             - '@annotation_reader'
+            - '@consistence.doctrine.enum.enum_fields_cache'
         tags:
             - { name: doctrine.event_listener, event: postLoad }
+
+    consistence.doctrine.enum.enum_fields_cache: '@consistence.doctrine.enum.enum_fields_cache_default'
+
+    consistence.doctrine.enum.enum_fields_cache_default:
+        class: Doctrine\Common\Cache\ArrayCache


### PR DESCRIPTION
Configuration for the new enum fields cache from https://github.com/consistence/consistence-doctrine/pull/7