### PR TITLE
Allow doctrine-bundle 2.0 and symfony 5 packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
 	"require": {
 		"php": "~7.2",
 		"consistence/consistence-doctrine": "~1.2|~2.0",
-		"doctrine/doctrine-bundle": "~1.3",
-		"symfony/config": "~3.0|~4.0",
-		"symfony/dependency-injection": "~3.0|~4.0",
-		"symfony/http-kernel": "~3.0|~4.0",
-		"symfony/yaml": "~3.0|~4.0"
+		"doctrine/doctrine-bundle": "~1.3|~2.0",
+		"symfony/config": "~3.0|~4.0|~5.0",
+		"symfony/dependency-injection": "~3.0|~4.0|~5.0",
+		"symfony/http-kernel": "~3.0|~4.0|~5.0",
+		"symfony/yaml": "~3.0|~4.0|~5.0"
 	},
 	"require-dev": {
 		"consistence/coding-standard": "3.7",


### PR DESCRIPTION
This contains the change from #13 - I am happy to rebase when/if it is merged.

I have tested this on a basic CRUD application along with generating migrations and no changes to the code were needed.