### PR TITLE
Refactor tests

### DIFF
--- a/tests/DependencyInjection/ConsistenceDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceDoctrineExtensionTest.php
@@ -12,6 +12,7 @@ use Consistence\Doctrine\Enum\Type\StringEnumType;
 use Consistence\Type\ArrayType\ArrayType;
 use Consistence\Type\ArrayType\KeyValuePair;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ConsistenceDoctrineExtensionTest extends \PHPUnit\Framework\TestCase
@@ -46,8 +47,8 @@ class ConsistenceDoctrineExtensionTest extends \PHPUnit\Framework\TestCase
 		$extension = new ConsistenceDoctrineExtension();
 		$extension->load([], $containerBuilder);
 
-		$this->assertTrue($containerBuilder->has('consistence.doctrine.enum.enum_post_load_entity_listener'));
-		$this->assertEquals(EnumPostLoadEntityListener::class, $containerBuilder->getDefinition('consistence.doctrine.enum.enum_post_load_entity_listener')->getClass());
+		Assert::assertTrue($containerBuilder->has('consistence.doctrine.enum.enum_post_load_entity_listener'));
+		Assert::assertEquals(EnumPostLoadEntityListener::class, $containerBuilder->getDefinition('consistence.doctrine.enum.enum_post_load_entity_listener')->getClass());
 	}
 
 	/**
@@ -80,7 +81,7 @@ class ConsistenceDoctrineExtensionTest extends \PHPUnit\Framework\TestCase
 	private function assertTypes(array $expectedTypes, array $actualTypes): void
 	{
 		foreach ($expectedTypes as $typeName => $typeClass) {
-			$this->assertTrue(ArrayType::containsByCallback(
+			Assert::assertTrue(ArrayType::containsByCallback(
 				$actualTypes,
 				static function (KeyValuePair $keyValuePair) use ($typeName, $typeClass): bool {
 					return $keyValuePair->getKey() === $typeName
@@ -88,7 +89,7 @@ class ConsistenceDoctrineExtensionTest extends \PHPUnit\Framework\TestCase
 				}
 			), sprintf('Expected type name: %s, class: %s missing', $typeName, $typeClass));
 		}
-		$this->assertCount(count($expectedTypes), $actualTypes);
+		Assert::assertCount(count($expectedTypes), $actualTypes);
 	}
 
 }

--- a/tests/DependencyInjection/ConsistenceDoctrineExtensionTest.php
+++ b/tests/DependencyInjection/ConsistenceDoctrineExtensionTest.php
@@ -48,7 +48,7 @@ class ConsistenceDoctrineExtensionTest extends \PHPUnit\Framework\TestCase
 		$extension->load([], $containerBuilder);
 
 		Assert::assertTrue($containerBuilder->has('consistence.doctrine.enum.enum_post_load_entity_listener'));
-		Assert::assertEquals(EnumPostLoadEntityListener::class, $containerBuilder->getDefinition('consistence.doctrine.enum.enum_post_load_entity_listener')->getClass());
+		Assert::assertSame(EnumPostLoadEntityListener::class, $containerBuilder->getDefinition('consistence.doctrine.enum.enum_post_load_entity_listener')->getClass());
 	}
 
 	/**


### PR DESCRIPTION
- [x]  stop calling static methods in tests as non-static
- [x] use assertSame() where assertEquals() is not explicitly needed
- [x] use assertCount() after assertContains() for array comparison
- [x] add missing Assert::fail() in try+catch blocks when expecting exceptions
- [x] unify Assert::fail() message
- [x] replace Consistence\TestCase::ok() with expectNotToPerformAssertions()
- [x] use try+catch+fail when expecting exceptions with properties
- [x] rename data providers to singular where applicable
- [x] use DataProvider suffix for data providers
- [x] change data provider return type from array to Generator
- [x] declare data provider values on separate lines
- [x] isolate data provider cases using Closures
- [x] name data provider values
- [x] name data provider cases
- [x] extract multiple cases from test methods to data providers
- [x] remove unnecessary private methods for creating mocks